### PR TITLE
Logging

### DIFF
--- a/Controller/ReportController.php
+++ b/Controller/ReportController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class ReportController extends AbstractController
 {
     private $logger;
-    private static $storageTest = [];
+
     
     public function __construct(LoggerInterface $logger)
     {
@@ -24,13 +24,8 @@ class ReportController extends AbstractController
      */
     public function report(Request $req)
     {
-        $this->logger->info($req->getContent());
-        array_push(ReportController::$storageTest, $req->getContent());
+        $this->logger->debug($req->getContent());
         $res = new JsonResponse($req->getContent());
         return $res;
-    }
-    public function index(Request $req)
-    {
-        return new JsonResponse(ReportController::$storageTest);
     }
 }

--- a/EventSubscriber/FetchMetadataRequestSubscriber.php
+++ b/EventSubscriber/FetchMetadataRequestSubscriber.php
@@ -16,12 +16,14 @@ class FetchMetadataRequestSubscriber implements EventSubscriberInterface
     private $fetchMetadataPolicyProvider;
     private $configProvider;
     private $logger;
+    private $requestBlockedMessage;
 
     public function __construct(FetchMetadataPolicyProvider $fetchMetadataPolicyProvider, ConfigProviderInterface $configProvider, LoggerInterface $securityLogger)
     {
         $this->fetchMetadataPolicyProvider = $fetchMetadataPolicyProvider;
         $this->configProvider = $configProvider;
         $this->logger = $securityLogger;
+        $this->requestBlockedMessage = '%1$s request from host %2$s blocked by Fetch Metadata Policy: %3$s';
     }
     public static function getSubscribedEvents()
     {
@@ -64,6 +66,7 @@ class FetchMetadataRequestSubscriber implements EventSubscriberInterface
             'policy' => $policy
         ];
         $fetchMetaPolicy = $policy ?? 'Default Policy';
-        $this->logger->debug($request->getMethod().' request from host '.$request->getUri().' blocked by Fetch Metadata Policy: '.$fetchMetaPolicy, $debugContext);
+        $rejectMessage = sprintf($this->requestBlockedMessage, $request->getMethod(), $request->getUri(), $fetchMetaPolicy);
+        $this->logger->debug($rejectMessage, $debugContext);
     }
 }

--- a/EventSubscriber/FetchMetadataRequestSubscriber.php
+++ b/EventSubscriber/FetchMetadataRequestSubscriber.php
@@ -16,14 +16,13 @@ class FetchMetadataRequestSubscriber implements EventSubscriberInterface
     private $fetchMetadataPolicyProvider;
     private $configProvider;
     private $logger;
-    private $requestBlockedMessage;
+    private $requestBlockedMessage = '%1$s request from host %2$s blocked by Fetch Metadata Policy: %3$s';
 
     public function __construct(FetchMetadataPolicyProvider $fetchMetadataPolicyProvider, ConfigProviderInterface $configProvider, LoggerInterface $securityLogger)
     {
         $this->fetchMetadataPolicyProvider = $fetchMetadataPolicyProvider;
         $this->configProvider = $configProvider;
         $this->logger = $securityLogger;
-        $this->requestBlockedMessage = '%1$s request from host %2$s blocked by Fetch Metadata Policy: %3$s';
     }
     public static function getSubscribedEvents()
     {

--- a/EventSubscriber/FetchMetadataRequestSubscriber.php
+++ b/EventSubscriber/FetchMetadataRequestSubscriber.php
@@ -4,7 +4,9 @@ namespace Ise\WebSecurityBundle\EventSubscriber;
 
 use Ise\WebSecurityBundle\Options\ConfigProviderInterface;
 use Ise\WebSecurityBundle\Policies\FetchMetadataPolicyProvider;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -13,10 +15,13 @@ class FetchMetadataRequestSubscriber implements EventSubscriberInterface
 {
     private $fetchMetadataPolicyProvider;
     private $configProvider;
-    public function __construct(FetchMetadataPolicyProvider $fetchMetadataPolicyProvider, ConfigProviderInterface $configProvider)
+    private $logger;
+
+    public function __construct(FetchMetadataPolicyProvider $fetchMetadataPolicyProvider, ConfigProviderInterface $configProvider, LoggerInterface $securityLogger)
     {
         $this->fetchMetadataPolicyProvider = $fetchMetadataPolicyProvider;
         $this->configProvider = $configProvider;
+        $this->logger = $securityLogger;
     }
     public static function getSubscribedEvents()
     {
@@ -32,14 +37,33 @@ class FetchMetadataRequestSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $options = $this->configProvider->getPathConfig($request);
         $fetchMetadataPolicy = $this->fetchMetadataPolicyProvider->getFetchMetadataPolicy($options['fetch_metadata']);
-
         if ($options['fetch_metadata']['active']) {
             $response = new Response();
             $response->headers->set('Vary', 'sec-fetch-site, sec-fetch-dest, sec-fetch-mode');
+
             if (!$fetchMetadataPolicy->applyPolicy($request)) {
+                $this->logRejection($request, $options['fetch_metadata']['policy']);
+
                 $response->setStatusCode(Response::HTTP_UNAUTHORIZED);
                 $event->setResponse($response);
             }
         }
+    }
+    /**
+     * Log rejection function. Logs if a request has been rejected by the fetch metadata policy.
+     * Records the Url, and which policy rejected the request.
+     *
+     * @param String $policy, A reference string to the Fetch Metadata policy used in the request. If Null assumed Default Policy
+     * @param Request $request, The request
+     * @return void
+     */
+    private function logRejection(Request $request, $policy): void
+    {
+        $debugContext = [
+            'request' => $request->getContent(),
+            'policy' => $policy
+        ];
+        $fetchMetaPolicy = $policy ?? 'Default Policy';
+        $this->logger->debug($request->getMethod().' request from host '.$request->getUri().' blocked by Fetch Metadata Policy: '.$fetchMetaPolicy, $debugContext);
     }
 }

--- a/Policies/FetchMetadataDefaultPolicy.php
+++ b/Policies/FetchMetadataDefaultPolicy.php
@@ -3,7 +3,6 @@
 namespace Ise\WebSecurityBundle\Policies;
 
 use Ise\WebSecurityBundle\Policies\FetchMetadataPolicyInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class FetchMetadataDefaultPolicy implements FetchMetadataPolicyInterface

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -12,6 +12,8 @@ services:
     arguments: 
       $fetchMetadataPolicyProvider: '@Ise\WebSecurityBundle\Policies\FetchMetadataPolicyProvider'
       $configProvider: '@Ise\WebSecurityBundle\Options\ConfigProvider'
+    tags:
+      - { name: monolog.logger, channel: security }
 
   Ise\WebSecurityBundle\EventSubscriber\FetchMetadataRequestSubscriber: '@ise_fetch_metadata.subscriber'
   

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -17,8 +17,6 @@ services:
   
   ise_fetch_metadata.default_policy:
     class: Ise\WebSecurityBundle\Policies\FetchMetadataDefaultPolicy
-    autowire: false
-    autoconfigure: false
     arguments:
       $corsEndpoints: []
 
@@ -33,7 +31,6 @@ services:
 
   ise_config.provider:
     class: Ise\WebSecurityBundle\Options\ConfigProvider
-    autowire: false
     arguments:
       $defaults: []
       $paths: []

--- a/Resources/config/services_dev.yaml
+++ b/Resources/config/services_dev.yaml
@@ -20,6 +20,9 @@ services:
     class: Ise\WebSecurityBundle\EventSubscriber\FetchMetadataRequestSubscriber
     arguments: 
       $fetchMetadataPolicy: '@?Ise\WebSecurityBundle\Policies\FetchMetadataDefaultPolicy'
+      $configProvider: '@Ise\WebSecurityBundle\Options\ConfigProvider'
+    tags:
+      - { name: monolog.logger, channel: security }
 
   Ise\WebSecurityBundle\EventSubscriber\FetchMetadataRequestSubscriber: '@ise_fetch_metadata.subscriber'
   

--- a/Resources/config/services_dev.yaml
+++ b/Resources/config/services_dev.yaml
@@ -25,8 +25,6 @@ services:
   
   ise_fetch_metadata.default_policy:
     class: Ise\WebSecurityBundle\Policies\FetchMetadataDefaultPolicy
-    autowire: false
-    autoconfigure: false
     arguments:
       $corsEndpoints: []
 
@@ -41,7 +39,6 @@ services:
 
   ise_config.provider:
     class: Ise\WebSecurityBundle\Options\ConfigurationProvider
-    autowire: false
     arguments:
       $defaults: []
       $paths: []

--- a/tests/FetchMetadataPolicyTest.php
+++ b/tests/FetchMetadataPolicyTest.php
@@ -8,6 +8,7 @@ use Ise\WebSecurityBundle\EventSubscriber\FetchMetadataRequestSubscriber;
 use Ise\WebSecurityBundle\Policies\FetchMetadataPolicyProvider;
 use Ise\WebSecurityBundle\Options\ConfigProvider;
 use Ise\WebSecurityBundle\Policies\FetchMetadataDefaultPolicy;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -24,9 +25,15 @@ class IseWebSecurityFetchMetadataPolicyTest extends TestCase
     public function testFetchMetaDataSubscriber()
     {
         $fetchMetaPolicy = new FetchMetadataDefaultPolicy([]);
+
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $requestSubscriber = new FetchMetadataRequestSubscriber(
             new FetchMetadataPolicyProvider,
-            new ConfigProvider($this->defaults, [])
+            new ConfigProvider($this->defaults, []),
+            $logger
         );
         
         $req = Request::create(


### PR DESCRIPTION
Fixes #14 

Implemented a high level logging for Fetch Metadata policies. The log is active only in Dev and will provide context with respect to the policy that caused the block and the request that caused the issues.

- [x] Tests pass
- [x] Coverage > 90%