### PR TITLE
Presets config extension

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,6 +19,8 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('defaults')
+                    ->addDefaultsIfNotSet()
+                    ->append($this->getPreset())
                     ->append($this->getReportConfig())
                     ->append($this->getCOEP())
                     ->append($this->getCOOP())
@@ -29,6 +31,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('path')
                     ->normalizeKeys(false)
                     ->prototype('array')
+                        ->append($this->getPreset())
                         ->append($this->getReportConfig())
                         ->append($this->getCOEP())
                         ->append($this->getCOOP())
@@ -45,9 +48,9 @@ class Configuration implements ConfigurationInterface
         $node = new ArrayNodeDefinition('coop');
         $node
         ->children()
-            ->booleanNode('active')->defaultTrue()->end()
-            ->booleanNode('policy_overwrite')->defaultFalse()->end()
-            ->scalarNode('policy')->defaultValue('same-origin')->end()
+            ->booleanNode('active')->end()
+            ->booleanNode('policy_overwrite')->end()
+            ->scalarNode('policy')->end()
         ->end();
         return $node;
     }
@@ -57,9 +60,9 @@ class Configuration implements ConfigurationInterface
         $node = new ArrayNodeDefinition('coep');
         $node
         ->children()
-            ->booleanNode('active')->defaultTrue()->end()
-            ->booleanNode('policy_overwrite')->defaultFalse()->end()
-            ->scalarNode('policy')->defaultValue('require-corp')->end()
+            ->booleanNode('active')->end()
+            ->booleanNode('policy_overwrite')->end()
+            ->scalarNode('policy')->end()
         ->end();
         return $node;
     }
@@ -68,9 +71,9 @@ class Configuration implements ConfigurationInterface
     {
         $node = new ArrayNodeDefinition('fetch_metadata');
         $node->children()
-            ->booleanNode('active')->defaultFalse()->end()
-            ->scalarNode('policy')->defaultNull()->end()
-            ->arrayNode('allowed_endpoints')->prototype('scalar')->defaultValue(array())->end()
+            ->booleanNode('active')->end()
+            ->scalarNode('policy')->end()
+            ->arrayNode('allowed_endpoints')->prototype('scalar')->end()
         ->end();
         return $node;
     }
@@ -78,7 +81,12 @@ class Configuration implements ConfigurationInterface
     private function getReportConfig()
     {
         $node = new ScalarNodeDefinition('report_uri');
-        $node->defaultNull();
+        return $node;
+    }
+
+    private function getPreset()
+    {
+        $node = new ScalarNodeDefinition('preset');
         return $node;
     }
 }

--- a/DependencyInjection/IseWebSecurityExtension.php
+++ b/DependencyInjection/IseWebSecurityExtension.php
@@ -26,8 +26,15 @@ class IseWebSecurityExtension extends Extension
         );
         $loader->load('services.yaml');
         
+        $presets = Yaml::parseFile(__DIR__.'/../Resources/config/presets.yaml')['presets'];
+        
+        if (isset($defaults['preset'])) {
+            $defaults = array_merge($defaults, $presets[$defaults['preset']]);
+        }
+        
         $configProvider = $container->getDefinition('ise_config.provider');
         $configProvider->setArgument('$defaults', $defaults);
         $configProvider->setArgument('$paths', $config['paths']);
+        $configProvider->setArgument('$presets', $presets);
     }
 }

--- a/DependencyInjection/IseWebSecurityExtension.php
+++ b/DependencyInjection/IseWebSecurityExtension.php
@@ -5,28 +5,27 @@ use Exception;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Yaml\Yaml;
 
 class IseWebSecurityExtension extends Extension
 {
+    private const CONFIG_PATH = __DIR__.'/../Resources/config';
     public function load(array $configs, ContainerBuilder $container)
     {
         //!Work in progress as described in Configuration.php To be rebuild in #7 and #3
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
-        
+
         $defaults = $config['defaults'];
         
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__.'/../Resources/config')
+            new FileLocator(self::CONFIG_PATH)
         );
         $loader->load('services.yaml');
         
-        $presets = Yaml::parseFile(__DIR__.'/../Resources/config/presets.yaml')['presets'];
+        $presets = Yaml::parseFile(self::CONFIG_PATH.'/presets.yaml')['presets'];
         
         if (isset($defaults['preset'])) {
             $defaults = array_merge($defaults, $presets[$defaults['preset']]);

--- a/Options/ConfigProvider.php
+++ b/Options/ConfigProvider.php
@@ -23,26 +23,37 @@ class ConfigProvider implements ConfigProviderInterface
      */
     private $defaults;
 
-    public function __construct($defaults = [], $paths = [])
+    private $presets;
+
+    public function __construct($defaults = [], $paths = [], $presets = [])
     {
         $this->defaults = $defaults;
         $this->paths = $paths;
+        $this->presets = $presets;
     }
     /**
      * getPathConfig parses the request uri and attempt to match it against a path config, where the path config is used as a regex to match against the uri.
      * If no config is found, the default config is returned.
      * If a config is found, then the default and the path config is merged and returned in $options.
      * Path config is order dependant. IF '^/api' comes before '^/' in the config, then '^/api' will be applied and '^/' disregarded provided the first matches.
+     * Presets overwrite ALL config for a route, such that any config made in a route is ignored in favour of the defined configuration.
      * @param Request $request The request that is to be configured
      * @return array The Config to be applied to the Request.
      */
     public function getPathConfig(Request $request): array
     {
-        $uri = $request->getPathInfo() ?: '/';
+        $uri = $request->getPathInfo() ?? '/';
         foreach ($this->paths as $pathReg => $options) {
-            //Check if there is a config that matches the ui
+            //Remove NULL's to prevent overwriting with defaults. 
+            $options = array_filter($options);
+            //Check if there is a config that matches the URI
+
             if (preg_match('{'.$pathReg.'}i', $uri)) {
-                $options = array_merge($this->defaults, $options);
+                if (isset($options['preset'])) {
+                    $options = array_merge($this->presets[$options['preset']], $options);
+                } else {
+                    $options = array_merge($this->defaults, $options);
+                }
                 return $options;
             }
         }

--- a/Options/ConfigProvider.php
+++ b/Options/ConfigProvider.php
@@ -44,7 +44,7 @@ class ConfigProvider implements ConfigProviderInterface
     {
         $uri = $request->getPathInfo() ?? '/';
         foreach ($this->paths as $pathReg => $options) {
-            //Remove NULL's to prevent overwriting with defaults. 
+            //Remove NULL's to prevent overwriting with defaults.
             $options = array_filter($options);
             //Check if there is a config that matches the URI
 

--- a/Options/ConfigProvider.php
+++ b/Options/ConfigProvider.php
@@ -36,7 +36,7 @@ class ConfigProvider implements ConfigProviderInterface
      * If no config is found, the default config is returned.
      * If a config is found, then the default and the path config is merged and returned in $options.
      * Path config is order dependant. IF '^/api' comes before '^/' in the config, then '^/api' will be applied and '^/' disregarded provided the first matches.
-     * Presets overwrite ALL config for a route, such that any config made in a route is ignored in favour of the defined configuration.
+     * Path based config will overwrite corresponding config in presets. 
      * @param Request $request The request that is to be configured
      * @return array The Config to be applied to the Request.
      */

--- a/Options/ConfigProvider.php
+++ b/Options/ConfigProvider.php
@@ -36,7 +36,7 @@ class ConfigProvider implements ConfigProviderInterface
      * If no config is found, the default config is returned.
      * If a config is found, then the default and the path config is merged and returned in $options.
      * Path config is order dependant. IF '^/api' comes before '^/' in the config, then '^/api' will be applied and '^/' disregarded provided the first matches.
-     * Path based config will overwrite corresponding config in presets. 
+     * Path based config will overwrite corresponding config in presets.
      * @param Request $request The request that is to be configured
      * @return array The Config to be applied to the Request.
      */

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Due to a lack of Symfony Flex recipe to do so automatically. In your projects `/
 
 ## Config
 
+More Config details can be found [here](https://github.com/GoogleChromeLabs/IseWebSecurityBundle/wiki/Configuration)
+
 >WIP, Config will change over time
 
 The config within your Symfony project will control how the bundle works in your Application.
@@ -57,6 +59,10 @@ ise_web_security:
             fetch_metadata:
                 allowed_endpoints: ['/images']
 ```
+
+## Wiki
+
+This Repo has a wiki! Check it out [here](https://github.com/GoogleChromeLabs/IseWebSecurityBundle/wiki)
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -43,23 +43,19 @@ the majority of the features. The `ise_web_security.yaml.dist` is also an exampl
 
 ```yaml
 ise_web_security:
-        defaults:
+    defaults: 
+        preset: 'full'
+    paths:
+        '^/public':
             coop:
                 active: false
             coep:
-                active: true
-                policy: 'require-corp'
+                active: false
             fetch_metadata:
-                active: true
-        paths:
-            '^/user':
-                coop:
-                    active: true
-                    policy: 'same-origin'
-                coep:
-                    active: false
-                fetch_metadata: 
-                    active: false
+                active: false
+        '^/admin':
+            fetch_metadata:
+                allowed_endpoints: ['/images']
 ```
 
 ## 🤝 Contributing

--- a/Resources/config/presets.yaml
+++ b/Resources/config/presets.yaml
@@ -1,0 +1,32 @@
+# Work in progress. Changes need to be made to accommodate reporting headers. At present COOP and COEP do not have reporting endpoints available.
+presets:
+  full:
+    coop:
+      active: true
+      policy: 'same-origin'
+    coep: 
+      active: true
+      policy: 'require-corp'
+    fetch_metadata:
+      active: true
+      allowed_endpoints: []
+  public:
+    coop:
+      active: true
+      policy: 'cross-site'
+    coep:
+      active: true
+      policy: 'unsafe-none'
+    fetch_metdata:
+      active: false
+      allowed_endpoints: []
+  same_site_restricted:
+    coop:
+      active: true
+      policy: 'same-site'
+    coep:
+      active: true
+      policy: 'require-corp'
+    fetch_metadata:
+      active: true
+      allowed_endpoints: []

--- a/Resources/config/presets.yaml
+++ b/Resources/config/presets.yaml
@@ -17,7 +17,7 @@ presets:
     coep:
       active: true
       policy: 'unsafe-none'
-    fetch_metdata:
+    fetch_metadata:
       active: false
       allowed_endpoints: []
   same_site_restricted:

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -37,5 +37,6 @@ services:
     arguments:
       $defaults: []
       $paths: []
+      $presets: []
 
   Ise\WebSecurityBundle\Options\ConfigProvider: '@ise_config.provider'

--- a/ise_web_security.yaml.dist
+++ b/ise_web_security.yaml.dist
@@ -1,12 +1,6 @@
 ise_web_security:
     defaults: 
-        coop:
-            active: true
-        coep:
-            active: true
-        fetch_metadata:
-            active: true
-            allowed_endpoints: []
+        preset: 'full'
     paths:
         '^/public':
             coop:
@@ -15,3 +9,5 @@ ise_web_security:
                 active: false
             fetch_metadata:
                 active: false
+        '^/admin':
+            preset: 'full'

--- a/tests/ConfigProviderTest.php
+++ b/tests/ConfigProviderTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 class IseWebSecurityConfigProviderTest extends TestCase
 {
     protected $defaultOptions = [
+        'preset' => null,
         'fetch_metadata' => [
             'active' => true,
             'policy' => null,
@@ -28,6 +29,7 @@ class IseWebSecurityConfigProviderTest extends TestCase
     ];
 
     protected $routeMatch = [
+        'preset' => null,
         'fetch_metadata' => [
             'active' => false,
             'policy' => null,
@@ -46,6 +48,7 @@ class IseWebSecurityConfigProviderTest extends TestCase
     ];
 
     protected $routeExactMatch = [
+        'preset' => null,
         'fetch_metadata' => [
             'active' => false,
             'policy' => null,
@@ -64,6 +67,7 @@ class IseWebSecurityConfigProviderTest extends TestCase
     ];
 
     protected $routeNoMatch = [
+        'preset' => null,
         'fetch_metadata' => [
             'active' => false,
             'policy' => null,
@@ -82,6 +86,45 @@ class IseWebSecurityConfigProviderTest extends TestCase
     ];
 
     protected $routeOverwrite = [
+        'preset' => null,
+        'fetch_metadata' => [
+            'active' => false,
+            'policy' => 'App\A\Random\Thing',
+            'allowed_origins' => ['/orign1','/origin2']
+        ],
+        'coop' => [
+            'active' => false,
+            'policy' => 'no match',
+            'policy_overwrite' => true
+        ],
+        'coep' => [
+            'active' => false,
+            'policy' => 'no match',
+            'policy_overwrite' => true
+        ]
+    ];
+
+    protected $fullPreset = [
+        'preset' => 'full',
+        'fetch_metadata' => [
+            'active' => false,
+            'policy' => 'App\A\Random\Preset',
+            'allowed_origins' => ['/orign1','/origin2']
+        ],
+        'coop' => [
+            'active' => true,
+            'policy' => 'preset',
+            'policy_overwrite' => true
+        ],
+        'coep' => [
+            'active' => false,
+            'policy' => 'preset',
+            'policy_overwrite' => true
+        ]
+    ];
+
+    protected $routeOverwritePreset = [
+        'preset' => 'full',
         'fetch_metadata' => [
             'active' => false,
             'policy' => 'App\A\Random\Thing',
@@ -144,6 +187,25 @@ class IseWebSecurityConfigProviderTest extends TestCase
         );
     }
 
+    public function testPresetOverwrite(): void
+    {
+        $provider = $this->getProvider();
+        $this->assertEquals(
+            $this->fullPreset,
+            $provider->getPathConfig(Request::create('/full/preset'))
+        );
+    }
+
+    public function testPathOverwritePreset(): void
+    {
+        $provider = $this->getProvider();
+
+        $this->assertEquals(
+            $this->routeOverwritePreset,
+            $provider->getPathConfig(Request::create('/overwrite/preset'))
+        );
+    }
+
     public function getProvider(): ConfigProviderInterface
     {
         return new ConfigProvider(
@@ -151,8 +213,15 @@ class IseWebSecurityConfigProviderTest extends TestCase
             [
                 '/test/exact' => $this->routeExactMatch,
                 '^/test/regex' => $this->routeMatch,
-                '/no/match' =>$this->routeNoMatch,
-                '/full/overwrite' =>$this->routeOverwrite
+                '/no/match' => $this->routeNoMatch,
+                '/full/overwrite' => $this->routeOverwrite,
+                '/full/preset' => [
+                    'preset' => 'full'
+                ],
+                '/overwrite/preset' => $this->routeOverwritePreset
+            ],
+            [
+                'full' => $this->fullPreset
             ]
         );
     }


### PR DESCRIPTION
Fixes #19 

PR extends the config provider to consume presets loaded during the dependency injection stage.
Includes base "global" presets that are there to be extended by a future PR

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Documentation updates added