### PR TITLE
Added initial TT implementation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration implements ConfigurationInterface
                     ->append($this->getCOEP())
                     ->append($this->getCOOP())
                     ->append($this->getFetchmetaData())
+                    ->append($this->getTrustedTypes())
                 ->end()
 
                 ->arrayNode('paths')
@@ -36,6 +37,7 @@ class Configuration implements ConfigurationInterface
                         ->append($this->getCOEP())
                         ->append($this->getCOOP())
                         ->append($this->getFetchmetaData())
+                        ->append($this->getTrustedTypes())
                     ->end()
             ->end()
         ;
@@ -74,6 +76,17 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('active')->end()
             ->scalarNode('policy')->end()
             ->arrayNode('allowed_endpoints')->prototype('scalar')->end()
+        ->end();
+        return $node;
+    }
+
+    private function getTrustedTypes()
+    {
+        $node = new ArrayNodeDefinition('trusted_types');
+        $node->children()
+            ->booleanNode('active')->end()
+            ->arrayNode('policies')->prototype('scalar')->end()->end()
+            ->arrayNode('require_for')->prototype('scalar')->end()
         ->end();
         return $node;
     }

--- a/EventSubscriber/TrustedTypesSubscriber.php
+++ b/EventSubscriber/TrustedTypesSubscriber.php
@@ -3,6 +3,8 @@
 namespace Ise\WebSecurityBundle\EventSubscriber;
 
 use Ise\WebSecurityBundle\Options\ConfigProviderInterface;
+use Ise\WebSecurityBundle\Options\ContextChecker;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -14,10 +16,15 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class TrustedTypesSubscriber implements EventSubscriberInterface
 {
     private $configProvider;
+    private $context;
+    private $logger;
+    private $policyIssueMessage = "Trusted types policy already defined in CSP header in request from %s. This may cause unexpected behaviour.";
 
-    public function __construct(ConfigProviderInterface $configProvider)
+    public function __construct(ConfigProviderInterface $configProvider, ContextChecker $context, LoggerInterface $logger)
     {
         $this->configProvider = $configProvider;
+        $this->context = $context;
+        $this->logger = $logger;
     }
 
     public static function getSubscribedEvents()
@@ -35,11 +42,21 @@ class TrustedTypesSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
 
         $options = $this->configProvider->getPathConfig($request);
-
+        //Check is trusted types is active, if not then leave handler
+        if (!$options['trusted_types']['active']) {
+            return;
+        }
         //Check if CSP header is set
+        $this->context->checkSecure($request, 'Trusted types');
         $headerSet = $response->headers->has("Content-Security-Policy");
         //If CSP header is set, pull it and append a ';' separator, else set an empty prefix.
         $headerPrefix = $headerSet ? $response->headers->get("Content-Security-Policy").';' : '';
+        //Check if trusted types policy is set. If so, print unexpected behaviour error
+        if (strpos($headerPrefix, 'trusted-types')) {
+            $policyIssue = sprintf($this->policyIssueMessage, $request->getUri());
+            $this->logger->log(0, $policyIssue, ['CSP header' => $headerPrefix]);
+        }
+        
         //Set trusted types CSP policy, and append it to the current policy if one exists
         $response->headers->set("Content-Security-Policy", $this->constructTrustedTypesHeader($options['trusted_types'], $headerPrefix));
     }
@@ -51,12 +68,12 @@ class TrustedTypesSubscriber implements EventSubscriberInterface
      * @param String $headerSet
      * @return String
      */
-    private function constructTrustedTypesHeader($options, $headerSet)
+    private function constructTrustedTypesHeader($options, $headerPrefix)
     {
         $policies = "trusted-types ".implode(" ", $options['policies']);
         $requireFor = "require-trusted-types-for ".implode(" ", array_map(function ($value) {
             return sprintf('\'%s\'', $value);
         }, $options['require_for']));
-        return sprintf("%s %s; %s;", $headerSet, $policies, $requireFor);
+        return sprintf("%s %s; %s;", $headerPrefix, $policies, $requireFor);
     }
 }

--- a/EventSubscriber/TrustedTypesSubscriber.php
+++ b/EventSubscriber/TrustedTypesSubscriber.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Ise\WebSecurityBundle\EventSubscriber;
+
+use Ise\WebSecurityBundle\Options\ConfigProviderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class TrustedTypesSubscriber implements EventSubscriberInterface
+{
+    private $configProvider;
+
+    public function __construct(ConfigProviderInterface $configProvider)
+    {
+        $this->configProvider = $configProvider;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => [
+                ['responseEvent', 0],
+            ]
+        ];
+    }
+
+    public function responseEvent(ResponseEvent $event)
+    {
+        $response = $event->getResponse();
+        $request = $event->getRequest();
+
+        $options = $this->configProvider->getPathConfig($request);
+
+        $headerSet = $response->headers->has("Content-Security-Policy") ? ";" : "";
+        $response->headers->set("Content-Security-Policy", $this->constructTrustedTypesHeader($options['trusted_types'], $headerSet));
+    }
+
+    private function constructTrustedTypesHeader($options, $headerSet) {
+        $policies = "trusted-types ".implode(" ", $options['policies']);
+        $requireFor = "require-trusted-types-for ".implode(" ", array_map(function ($value) { return sprintf('\'%s\'', $value); }, $options['require_for']));
+        return sprintf("%s %s; %s;", $headerSet, $policies, $requireFor);
+    }
+}

--- a/EventSubscriber/TrustedTypesSubscriber.php
+++ b/EventSubscriber/TrustedTypesSubscriber.php
@@ -37,9 +37,12 @@ class TrustedTypesSubscriber implements EventSubscriberInterface
         $response->headers->set("Content-Security-Policy", $this->constructTrustedTypesHeader($options['trusted_types'], $headerSet));
     }
 
-    private function constructTrustedTypesHeader($options, $headerSet) {
+    private function constructTrustedTypesHeader($options, $headerSet)
+    {
         $policies = "trusted-types ".implode(" ", $options['policies']);
-        $requireFor = "require-trusted-types-for ".implode(" ", array_map(function ($value) { return sprintf('\'%s\'', $value); }, $options['require_for']));
+        $requireFor = "require-trusted-types-for ".implode(" ", array_map(function ($value) {
+            return sprintf('\'%s\'', $value);
+        }, $options['require_for']));
         return sprintf("%s %s; %s;", $headerSet, $policies, $requireFor);
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,21 +13,9 @@ including:
 
 # 🖥️ Usage
 
->WIP, package not currently published. 
+Install the package from Packagist:
 
-To install the bundle on a project, add the following lines to your composer.json
-
-```json
-"require": {
-    "ise/web-security-bundle": "dev-main"
-},
-"repositories": [
-    {
-        "type": "vcs",
-        "url": "https://github.com/GoogleChromeLabs/IseWebSecurityBundle.git"
-    }
-]
-```
+`composer require googlechromelabs/ise-web-security-bundle`
 
 Due to a lack of Symfony Flex recipe to do so automatically. In your projects `/config/packages` folder, create `ise_web_security.yaml` and populate it with the yaml config detailed below. 
 
@@ -35,7 +23,6 @@ Due to a lack of Symfony Flex recipe to do so automatically. In your projects `/
 
 More Config details can be found [here](https://github.com/GoogleChromeLabs/IseWebSecurityBundle/wiki/Configuration)
 
->WIP, Config will change over time
 
 The config within your Symfony project will control how the bundle works in your Application.
 Below, you will find an example config for the current state of the project that will activate

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ ise_web_security:
         '^/admin':
             fetch_metadata:
                 allowed_endpoints: ['/images']
+            trusted_types:
+                active: true
+                polices: ['foo', 'bar']
+                require_for: ['script', 'style']
+
 ```
 
 ## Wiki

--- a/Resources/config/presets.yaml
+++ b/Resources/config/presets.yaml
@@ -20,6 +20,8 @@ presets:
     fetch_metadata:
       active: false
       allowed_endpoints: []
+    trusted_types:
+      active: false
   same_site_restricted:
     coop:
       active: true
@@ -30,3 +32,5 @@ presets:
     fetch_metadata:
       active: true
       allowed_endpoints: []
+    trusted_types:
+      active: false

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -31,6 +31,13 @@ services:
 
   Ise\WebSecurityBundle\EventSubscriber\ResponseSubscriber: '@ise_coop_coep.subscriber'
 
+  Ise\WebSecurityBundle\EventSubscriber\TrustedTypesSubscriber: '@ise_trusted_types.subscriber'
+
+  ise_trusted_types.subscriber:
+    class: Ise\WebSecurityBundle\EventSubscriber\TrustedTypesSubscriber
+    arguments:
+      $configProvider: '@Ise\WebSecurityBundle\Options\ConfigProvider'
+
   ise_config.provider:
     class: Ise\WebSecurityBundle\Options\ConfigProvider
     arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
         <whitelist>
             <directory suffix=".php">Policies/</directory>
             <directory suffix=".php">Options/</directory>
+            <directory suffix=".php">EventSubscriber/</directory>
         </whitelist>
     </filter>
     <logging>

--- a/tests/COOPCOEPTest.php
+++ b/tests/COOPCOEPTest.php
@@ -72,3 +72,4 @@ class COOPCOEPTest extends TestCase
         $this->assertEquals($res->getResponse()->headers->get('Cross-Origin-Embedder-Policy'), $this->coep);
     }
 }
+    

--- a/tests/COOPCOEPTest.php
+++ b/tests/COOPCOEPTest.php
@@ -4,7 +4,9 @@ namespace Ise\WebSecurityBundle\Tests;
 
 use Ise\WebSecurityBundle\EventSubscriber\ResponseSubscriber;
 use Ise\WebSecurityBundle\Options\ConfigProvider;
+use Ise\WebSecurityBundle\Options\ContextChecker;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -28,8 +30,13 @@ class COOPCOEPTest extends TestCase
 
     public function testCOOP()
     {
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context = new ContextChecker($logger);
         $requestSub = new ResponseSubscriber(
-            new ConfigProvider($this->default, [])
+            new ConfigProvider($this->default, []),
+            $context
         );
 
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)
@@ -51,8 +58,13 @@ class COOPCOEPTest extends TestCase
 
     public function testCOEP()
     {
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context = new ContextChecker($logger);
         $requestSub = new ResponseSubscriber(
-            new ConfigProvider($this->default, [])
+            new ConfigProvider($this->default, []),
+            $context
         );
 
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)

--- a/tests/COOPCOEPTest.php
+++ b/tests/COOPCOEPTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Ise\WebSecurityBundle\Tests;
+
+use Ise\WebSecurityBundle\EventSubscriber\ResponseSubscriber;
+use Ise\WebSecurityBundle\Options\ConfigProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class COOPCOEPTest extends TestCase
+{
+    private $default = [
+        "coop" => [
+            "active" => true,
+            "policy" => 'same-origin'
+        ],
+        "coep" => [
+            "active" => true,
+            "policy" => 'require-corp'
+        ]
+    ];
+
+    private $coop = "same-origin";
+    private $coep = "require-corp";
+
+    public function testCOOP()
+    {
+        $requestSub = new ResponseSubscriber(
+            new ConfigProvider($this->default, [])
+        );
+
+        $kernel = $this->getMockBuilder(HttpKernelInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request = Request::create('/test');
+        $res = new ResponseEvent(
+            $kernel,
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $result = $requestSub->responseEvent($res);
+        $this->assertNull($result);
+        $this->assertEquals($res->getResponse()->headers->get('Cross-Origin-Opener-Policy'), $this->coop);
+    }
+
+    public function testCOEP()
+    {
+        $requestSub = new ResponseSubscriber(
+            new ConfigProvider($this->default, [])
+        );
+
+        $kernel = $this->getMockBuilder(HttpKernelInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request = Request::create('/test');
+        $res = new ResponseEvent(
+            $kernel,
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $result = $requestSub->responseEvent($res);
+        $this->assertNull($result);
+        $this->assertEquals($res->getResponse()->headers->get('Cross-Origin-Embedder-Policy'), $this->coep);
+    }
+}

--- a/tests/COOPCOEPTest.php
+++ b/tests/COOPCOEPTest.php
@@ -72,4 +72,3 @@ class COOPCOEPTest extends TestCase
         $this->assertEquals($res->getResponse()->headers->get('Cross-Origin-Embedder-Policy'), $this->coep);
     }
 }
-    

--- a/tests/FetchMetadataPolicyTest.php
+++ b/tests/FetchMetadataPolicyTest.php
@@ -36,10 +36,6 @@ class IseWebSecurityFetchMetadataPolicyTest extends TestCase
             $logger
         );
         
-        $req = Request::create(
-            '/blog'
-        );
-
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/TrustedTypesPolicyTest.php
+++ b/tests/TrustedTypesPolicyTest.php
@@ -4,7 +4,9 @@ namespace Ise\WebSecurityBundle\Tests;
 
 use Ise\WebSecurityBundle\EventSubscriber\TrustedTypesSubscriber;
 use Ise\WebSecurityBundle\Options\ConfigProvider;
+use Ise\WebSecurityBundle\Options\ContextChecker;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -26,8 +28,16 @@ class IseTrustedTypesPolicyTest extends TestCase
 
     public function testTrustedTypesSubscriberBase()
     {
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $context = new ContextChecker($logger);
+        
         $requestSub = new TrustedTypesSubscriber(
-            new ConfigProvider($this->defaults, [])
+            new ConfigProvider($this->defaults, []),
+            $context,
+            $logger
         );
 
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)
@@ -49,8 +59,16 @@ class IseTrustedTypesPolicyTest extends TestCase
 
     public function testTrustedTypesSubscriberCSPPrefix()
     {
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $context = new ContextChecker($logger);
+        
         $requestSub = new TrustedTypesSubscriber(
-            new ConfigProvider($this->defaults, [])
+            new ConfigProvider($this->defaults, []),
+            $context,
+            $logger
         );
 
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)

--- a/tests/TrustedTypesPolicyTest.php
+++ b/tests/TrustedTypesPolicyTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Ise\WebSecurityBundle\Tests;
+
+use Ise\WebSecurityBundle\EventSubscriber\TrustedTypesSubscriber;
+use Ise\WebSecurityBundle\Options\ConfigProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class IseTrustedTypesPolicyTest extends TestCase
+{
+    private $defaults = [
+        'trusted_types' => [
+            'active' => true,
+            'policies' => ['foo'],
+            'require_for' => ['script']
+        ]
+    ];
+
+    private $nonPrefixed = " trusted-types foo; require-trusted-types-for 'script';";
+    private $prefixed = "default-src 'script'; trusted-types foo; require-trusted-types-for 'script';";
+    private $CSP = "default-src 'script'";
+
+    public function testTrustedTypesSubscriberBase()
+    {
+        $requestSub = new TrustedTypesSubscriber(
+            new ConfigProvider($this->defaults, [])
+        );
+
+        $kernel = $this->getMockBuilder(HttpKernelInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request = Request::create('/test');
+        $res = new ResponseEvent(
+            $kernel,
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $result = $requestSub->responseEvent($res);
+        $this->assertNull($result);
+        $this->assertEquals($res->getResponse()->headers->get('Content-Security-Policy'), $this->nonPrefixed);
+    }
+
+    public function testTrustedTypesSubscriberCSPPrefix()
+    {
+        $requestSub = new TrustedTypesSubscriber(
+            new ConfigProvider($this->defaults, [])
+        );
+
+        $kernel = $this->getMockBuilder(HttpKernelInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request = Request::create('/test');
+        $res = new ResponseEvent(
+            $kernel,
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response('', 200, ['Content-Security-Policy' => $this->CSP])
+        );
+
+        $result = $requestSub->responseEvent($res);
+        $this->assertNull($result);
+        $this->assertEquals($res->getResponse()->headers->get('Content-Security-Policy'), $this->prefixed);
+    }
+}


### PR DESCRIPTION
Fixes #16 

Added a Trusted Types implementation to the ISE Security Bundle. This does **not** include a full CSP module. The idea for this, after discussion in the ISE group, was to implement TT in a way that would be compatable with other bundles (i.e nelmio security bundle), and would not lead to an overwritten or broken CSP header. 

- [x] Tests pass
- [x] Appropriate changes to README are included in PR