### PR TITLE
Forced 5.1.5 in http-kernel due to security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "symfony/config": "^4.3 || ^5.1",
         "symfony/dependency-injection": "^4.3 ||^5.1",
-        "symfony/http-kernel": "^4.3 ||^5.1",
+        "symfony/http-kernel": "^4.3 || ^5.1.5",
         "symfony/framework-bundle": "^4.3 || ^5.1"
     },
     "require-dev": {


### PR DESCRIPTION
Dependabot caught an issue with v5.1 for http-kernel
PR fixes associated security issue by bumping version to 5.1.5